### PR TITLE
Added alternative way to define routes on an endpoint using the Express route syntax and path parameters

### DIFF
--- a/dx-core-modules/endpoint-base.js
+++ b/dx-core-modules/endpoint-base.js
@@ -281,6 +281,14 @@ class DivbloxEndpointBase extends divbloxObjectBase {
     }
 
     /**
+     * Forces the result to the provided data
+     * Bypasses the setResult() and addResultDetail() functions
+     */
+    forceResult(data) {
+        this.result = data;
+    }
+
+    /**
      * Sets the result back to its initial state
      */
     resetResultDetail() {

--- a/dx-core-modules/endpoint-base.js
+++ b/dx-core-modules/endpoint-base.js
@@ -45,7 +45,7 @@ class DivbloxEndpointBase extends divbloxObjectBase {
 
     /**
      * Returns an operation definition that contains the information need to form a swagger documentation
-     * @param {string} definition.operationName Required. The name of the operation
+     * @param {string} definition.operationName Required. The name of the operation and the route that will be used. Express.js route syntax can be used
      * @param {[]} definition.allowedAccess Required. An array of Global Identifier Groupings that are allowed
      * to access this operation
      * @param {string} definition.operationDescription Optional. A description of what the operation does
@@ -60,6 +60,8 @@ class DivbloxEndpointBase extends divbloxObjectBase {
      * Use this.getSchema() to provide a properly formatted schema
      * @param {*} definition.additionalResponseSchemas Optional. Any additional response schemas that you want to specify that
      * are not of media type "application/json". Specified as {"[mediaType]": {[schema]}}
+     * @param {*} definition.f Optional. Can be used to provide a custom async function to handle the operation. Will get passed a req and res object from Express.  If this is not provided,
+     * the default operation handler "executeOperation" will be used. Specified as (req, res) => { ... }
      * @param {boolean} definition.disableSwaggerDoc If set to true, this operation will not be included in swagger UI
      * @return {
      * {allowedAccess: ([string]|*),
@@ -95,6 +97,7 @@ class DivbloxEndpointBase extends divbloxObjectBase {
             additionalRequestSchemas: {},
             additionalResponseSchemas: {},
             responses: {},
+            f : null,
             disableSwaggerDoc: false,
             successStatusCode: 200,
             successMessage: "OK",

--- a/dx-core-modules/endpoint-base.js
+++ b/dx-core-modules/endpoint-base.js
@@ -19,6 +19,7 @@ class DivbloxEndpointBase extends divbloxObjectBase {
             unauthorized: false,
             cookie: null,
         };
+        this.statusCode = null;
         this.declaredOperations = [];
         this.declaredSchemas = [];
         this.currentRequest = {};
@@ -283,9 +284,14 @@ class DivbloxEndpointBase extends divbloxObjectBase {
     /**
      * Forces the result to the provided data
      * Bypasses the setResult() and addResultDetail() functions
+     * @param {*} data The response data to return
+     * @param {number} statusCode The http status code to return
      */
-    forceResult(data) {
+    forceResult(data, statusCode = null) {
         this.result = data;
+        if (statusCode !== null) {
+            this.statusCode = statusCode;
+        }
     }
 
     /**
@@ -298,6 +304,7 @@ class DivbloxEndpointBase extends divbloxObjectBase {
             unauthorized: false,
             cookie: null,
         };
+        this.statusCode = null;
     }
 
     /**

--- a/dx-core-modules/web-service.js
+++ b/dx-core-modules/web-service.js
@@ -148,31 +148,29 @@ class DivbloxWebService extends divbloxObjectBase {
                 }
 
                 const path = "/" + endpointName + "/" + element.operationName;
-                const executeCallback = async (req, res) => {
+                const execute = async (req, res) => {
                     packageConfigInstance.resetResultDetail();
                     await element.f(req, res);
-                    delete packageConfigInstance.result["success"];
-                    delete packageConfigInstance.result["cookie"];
-                    delete packageConfigInstance.result["unauthorized"];
                     res.header("x-powered-by", "divbloxjs");
-                    res.send(packageConfigInstance.result);
+                    res.statusCode = packageConfigInstance.result.statusCode || 200;
+                    res.send(packageConfigInstance.result.message);
                 };
 
                 switch (element.requestType) {
                     case 'GET':
-                        router.get(path, executeCallback);
+                        router.get(path, execute);
                         break;
                     case 'POST':
-                        router.post(path, executeCallback);
+                        router.post(path, execute);
                         break;
                     case 'PUT':
-                        router.put(path, executeCallback);
+                        router.put(path, execute);
                         break;
                     case 'PATCH':
-                        router.patch(path, executeCallback);
+                        router.patch(path, execute);
                         break;
                     case 'DELETE':
-                        router.delete(path, executeCallback);
+                        router.delete(path, execute);
                         break;
                     default:
                         break;

--- a/dx-core-modules/web-service.js
+++ b/dx-core-modules/web-service.js
@@ -152,7 +152,7 @@ class DivbloxWebService extends divbloxObjectBase {
                     packageConfigInstance.resetResultDetail();
                     await operation.f(req, res);
                     res.header("x-powered-by", "divbloxjs");
-                    res.statusCode = packageConfigInstance.result.statusCode || operation.successStatusCode || 200;
+                    res.statusCode = packageConfigInstance.statusCode || operation.successStatusCode || 200;
                     res.send(packageConfigInstance.result);
                 };
 

--- a/dx-core-modules/web-service.js
+++ b/dx-core-modules/web-service.js
@@ -412,16 +412,20 @@ class DivbloxWebService extends divbloxObjectBase {
                 let parameters = operation.parameters || [];
                 let operationPath = '';
                 let pathParameters = operation.operationName.split('/');
-                for (const param of pathParameters) {
-                    if (param.startsWith(':')) {
-                        operationPath += '/{' + param.substring(1) + '}';
-                        parameters.push({
-                            in: "path",
-                            name: param.substring(1),
-                            required: true,
-                        });
+                for (const parameter of pathParameters) {
+                    if (parameter.startsWith(':')) {
+                        let parameterName = parameter.substring(1);
+                        operationPath += '/{' + parameterName + '}';
+                        if (!parameters.some(p => p.name == parameterName && p.in == 'path')) {
+                            parameters.push({
+                                in: "path",
+                                name: parameterName,
+                                required: true,
+                                description: "The " + parameterName + " path parameter",
+                            });
+                        }
                     } else {
-                        operationPath += '/' + param;
+                        operationPath += '/' + parameter;
                     }
                 }
 

--- a/dx-core-modules/web-service.js
+++ b/dx-core-modules/web-service.js
@@ -142,6 +142,43 @@ class DivbloxWebService extends divbloxObjectBase {
             const endpointName =
                 packageConfigInstance.endpointName === null ? packageName : packageConfigInstance.endpointName;
 
+            packageConfigInstance.declaredOperations.forEach(element => {
+                if (!element.f) {
+                    return;
+                }
+
+                const path = "/" + endpointName + "/" + element.operationName;
+                const executeCallback = async (req, res) => {
+                    packageConfigInstance.resetResultDetail();
+                    await element.f(req, res);
+                    delete packageConfigInstance.result["success"];
+                    delete packageConfigInstance.result["cookie"];
+                    delete packageConfigInstance.result["unauthorized"];
+                    res.header("x-powered-by", "divbloxjs");
+                    res.send(packageConfigInstance.result);
+                };
+
+                switch (element.requestType) {
+                    case 'GET':
+                        router.get(path, executeCallback);
+                        break;
+                    case 'POST':
+                        router.post(path, executeCallback);
+                        break;
+                    case 'PUT':
+                        router.put(path, executeCallback);
+                        break;
+                    case 'PATCH':
+                        router.patch(path, executeCallback);
+                        break;
+                    case 'DELETE':
+                        router.delete(path, executeCallback);
+                        break;
+                    default:
+                        break;
+                }
+            });
+
             router.all("/" + endpointName, async (req, res, next) => {
                 const packageInstance = new packageEndpoint(this.dxInstance);
 

--- a/dx-core-modules/web-service.js
+++ b/dx-core-modules/web-service.js
@@ -413,20 +413,24 @@ class DivbloxWebService extends divbloxObjectBase {
                 let operationPath = '';
                 let pathParameters = operation.operationName.split('/');
                 for (const parameter of pathParameters) {
-                    if (parameter.startsWith(':')) {
-                        let parameterName = parameter.substring(1);
-                        operationPath += '/{' + parameterName + '}';
-                        if (!parameters.some(p => p.name == parameterName && p.in == 'path')) {
-                            parameters.push({
-                                in: "path",
-                                name: parameterName,
-                                required: true,
-                                description: "The " + parameterName + " path parameter",
-                            });
-                        }
-                    } else {
+                    if (!parameter.startsWith(':')) {
                         operationPath += '/' + parameter;
+                        continue;
                     }
+
+                    let parameterName = parameter.substring(1);
+                    operationPath += '/{' + parameterName + '}';
+                
+                    if (parameters.some(p => p.name == parameterName && p.in == 'path')) {
+                        continue;
+                    }
+
+                    parameters.push({
+                        in: "path",
+                        name: parameterName,
+                        required: true,
+                        description: "The " + parameterName + " path parameter",
+                    });
                 }
 
                 const path = "/" + endpointName + operationPath;


### PR DESCRIPTION
This gives us the ability to cater for RESTful API endpoints
Added an extra level of routing that will catch these new endpoint operations but still forward the existing operations to the default package route