### PR TITLE
Minor fix to allow for valid entity names that are not part of relationship chain to be added to data series result at the root level of object. Currently being skipped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "divbloxjs",
-    "version": "2.0.0-beta.10",
+    "version": "2.0.0-beta.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "divbloxjs",
-            "version": "2.0.0-beta.10",
+            "version": "2.0.0-beta.11",
             "license": "MIT",
             "dependencies": {
                 "cookie-parser": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "divbloxjs",
-    "version": "2.0.0-beta.10",
+    "version": "2.0.0-beta.11",
     "description": "The divblox node.js backend",
     "main": "divblox.js",
     "scripts": {


### PR DESCRIPTION
Minor fix:

- Allow for valid entity names that are not part of relationship chain to be added to data series result at the root level of object. 
- Currently they are being skipped